### PR TITLE
Improve unassign condition with reminder label logic

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -39552,7 +39552,14 @@ var ScheduleHandler = class {
           const hasReminderLabel = (_b = (_a = result.issue) == null ? void 0 : _a.labels) == null ? void 0 : _b.some(
             (label) => (label == null ? void 0 : label.name) === "\u{1F514} reminder-sent"
           );
-          if (result.daysSinceActivity >= daysUntilUnassign) {
+          let shouldUnassign = result.daysSinceActivity >= daysUntilUnassign;
+          if (hasReminderLabel) {
+            shouldUnassign = shouldUnassign || // The last day of activity is (normally) the point in time where the reminder label was sent.
+            // Thus, reminderDays already passed of the number of daysUntilUnassign.
+            // Therefore, we substract reminderDays from daysUntilUnassign to know the "real" period to wait for.
+            result.daysSinceActivity >= daysUntilUnassign - reminderDays;
+          }
+          if (shouldUnassign) {
             unassignIssues.push(__spreadProps(__spreadValues({}, result), { hasReminderLabel }));
             continue;
           }

--- a/src/handlers/schedule-handler.ts
+++ b/src/handlers/schedule-handler.ts
@@ -152,13 +152,14 @@ export default class ScheduleHandler {
           (label) => label?.name === '🔔 reminder-sent',
         );
 
-        boolean shouldUnassign = (result.daysSinceActivity >= daysUntilUnassign);
+        let shouldUnassign = result.daysSinceActivity >= daysUntilUnassign;
         if (hasReminderLabel) {
-          shouldUnassign = shouldUnassign ||
+          shouldUnassign =
+            shouldUnassign ||
             // The last day of activity is (normally) the point in time where the reminder label was sent.
             // Thus, reminderDays already passed of the number of daysUntilUnassign.
             // Therefore, we substract reminderDays from daysUntilUnassign to know the "real" period to wait for.
-            (result.daysSinceActivity >= (daysUntilUnassign - reminderDays));
+            result.daysSinceActivity >= daysUntilUnassign - reminderDays;
         }
         if (shouldUnassign) {
           unassignIssues.push({ ...result, hasReminderLabel });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💡 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Description

The last day of activity is (normally) the point in time where the reminder label was sent.
Thus, reminderDays already passed of the number of daysUntilUnassign.
Therefore, we substract reminderDays from daysUntilUnassign to know the "real" period to wait for.

## Related Tickets & Documents

Fixes https://github.com/takanome-dev/assign-issue-action/issues/380

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

<!-- note: PRs with deleted sections will be marked invalid -->
