### PR TITLE
feat: prevent assignment on closed issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -318,6 +318,25 @@ inputs:
 
       Hi @{{ handle }}, you cannot self-assign issues. Please reach out to maintainers for the next steps.
 
+  closed_issue_assignment_comment:
+    description: Message shown when a user tries to assign themselves to a closed issue
+    required: false
+    default: |
+      ### ⚠️ Assignment Not Possible
+
+      Hi @{{ handle }}, you cannot assign yourself to a closed issue.
+
+      > [!NOTE]
+      > Assignment is only available for open issues.
+
+      <details>
+      <summary>What you can do</summary>
+
+      - Search for open issues in the repository
+      - Ask a maintainer if the issue should be reopened
+      - Look for similar open issues to contribute to
+      </details>
+
 outputs:
   assigned:
     description: Boolean indicating if the issue was assigned (yes/no)

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -38818,6 +38818,7 @@ let INPUTS = /* @__PURE__ */ function(INPUTS$1) {
 	INPUTS$1["SELF_ASSIGN_AUTHOR_BLOCKED_COMMENT"] = "self_assign_author_blocked_comment";
 	INPUTS$1["IGNORED_USERS"] = "ignored_users";
 	INPUTS$1["IGNORED_MESSAGE"] = "ignored_message";
+	INPUTS$1["CLOSED_ISSUE_ASSIGNMENT_COMMENT"] = "closed_issue_assignment_comment";
 	return INPUTS$1;
 }({});
 
@@ -38923,6 +38924,11 @@ var CommentHandler = class {
 	}
 	async $_handle_self_assignment() {
 		core.info(`🤖 Starting assignment for issue #${this.issue?.number} in repo "${this.context.repo.owner}/${this.context.repo.repo}"`);
+		if (this.issue?.state === "closed") {
+			await this._create_comment(INPUTS.CLOSED_ISSUE_ASSIGNMENT_COMMENT, { handle: this.comment?.user?.login });
+			core.setOutput("assigned", "no");
+			return core.info(`[CLOSED ISSUE] User @${this.comment?.user?.login} tried to assign themselves to closed issue #${this.issue?.number}`);
+		}
 		const allowSelfAssignAuthor = core.getInput(INPUTS.ALLOW_SELF_ASSIGN_AUTHOR) !== "false";
 		const isIssueAuthor = this.issue?.user?.login === this.comment?.user?.login;
 		if (!allowSelfAssignAuthor && isIssueAuthor) {

--- a/src/handlers/comment-handler.ts
+++ b/src/handlers/comment-handler.ts
@@ -10,6 +10,7 @@ import type {
   AlreadyAssignedCommentArg,
   AssignmentInterestCommentArg,
   AssignUserCommentArg,
+  ClosedIssueAssignmentCommentArg,
   UnAssignUserCommentArg,
 } from '../types/comment'
 
@@ -248,6 +249,20 @@ export default class CommentHandler {
     core.info(
       `🤖 Starting assignment for issue #${this.issue?.number} in repo "${this.context.repo.owner}/${this.context.repo.repo}"`,
     )
+
+    // Check if issue is closed
+    if (this.issue?.state === 'closed') {
+      await this._create_comment<ClosedIssueAssignmentCommentArg>(
+        INPUTS.CLOSED_ISSUE_ASSIGNMENT_COMMENT,
+        {
+          handle: this.comment?.user?.login,
+        },
+      )
+      core.setOutput('assigned', 'no')
+      return core.info(
+        `[CLOSED ISSUE] User @${this.comment?.user?.login} tried to assign themselves to closed issue #${this.issue?.number}`,
+      )
+    }
 
     // Check if author self-assignment is allowed
     const allowSelfAssignAuthor =

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -20,3 +20,7 @@ export interface UnAssignUserCommentArg {
   handle: string
   pin_label: string
 }
+
+export interface ClosedIssueAssignmentCommentArg {
+  handle: string
+}

--- a/src/utils/lib/inputs.ts
+++ b/src/utils/lib/inputs.ts
@@ -38,4 +38,6 @@ export enum INPUTS {
 
   IGNORED_USERS = 'ignored_users',
   IGNORED_MESSAGE = 'ignored_message',
+
+  CLOSED_ISSUE_ASSIGNMENT_COMMENT = 'closed_issue_assignment_comment',
 }


### PR DESCRIPTION
## Summary
- Prevents users from self-assigning closed issues
- Displays clear error message when users attempt to use `/assign-me` on closed issues
- Adds configurable `closed_issue_assignment_comment` input for customizing the error message

## Changes
- ✅ Added state validation check at the beginning of self-assignment flow
- ✅ Added `closed_issue_assignment_comment` input to action.yml with default error message
- ✅ Added `CLOSED_ISSUE_ASSIGNMENT_COMMENT` enum to inputs.ts
- ✅ Added `ClosedIssueAssignmentCommentArg` TypeScript type
- ✅ Updated dist/index.mjs with bundled changes

## Behavior
When a user attempts `/assign-me` on a closed issue:
1. Bot checks issue state before any other validations (fail-fast)
2. Responds with: "⚠️ Assignment Not Possible - You cannot assign yourself to a closed issue"
3. Suggests alternatives: search for open issues, ask maintainer to reopen, find similar open issues
4. Does not assign the user
5. Sets output `assigned: no`
6. Logs the attempt for monitoring

## Test Plan
- [x] Build succeeds without errors
- [ ] Manual test: Comment `/assign-me` on closed issue → receives error message
- [ ] Verify user is not assigned
- [ ] Verify open issues still work normally

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)