### PR TITLE
fix: cleanup orphaned labels and prevent repetitive comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 <h2 align="center">💬 Assign Issue Action ✋</h2>
 
-<p align="center"><a href="https://github.com/takanome-dev/assign-issue-action"><img alt="Licence Badge" src="https://img.shields.io/github/license/takanome-dev/assign-issue-action?color=%2330C151"></a> <a href="https://github.com/takanome-dev/assign-issue-action"><img alt="Release Badge" src="https://img.shields.io/github/release/takanome-dev/assign-issue-action?color=%2330C151"></a> <a href="https://github.com/takanome-dev/assign-issue-action"><img alt="GitHub Actions status" src="https://github.com/takanome-dev/assign-issue-action/actions/workflows/development.yml/badge.svg"></a> <a href="https://github.com/takanome-dev/assign-issue-action"><img alt="GitHub Actions status" src="https://github.com/takanome-dev/assign-issue-action/actions/workflows/codeql-analysis.yml/badge.svg"></a> <a href="https://codecov.io/gh/takanome-dev/assign-issue-action"><img src="https://codecov.io/gh/takanome-dev/assign-issue-action/branch/beta/graph/badge.svg?token=MX3SB0GFB3" /></a></p>
+<p align="center">
+    <a href="https://github.com/takanome-dev/assign-issue-action">
+        <img alt="Licence Badge" src="https://img.shields.io/github/license/takanome-dev/assign-issue-action?color=%2330C151">
+    </a>
+    <a href="https://github.com/takanome-dev/assign-issue-action">
+        <img alt="Release Badge" src="https://img.shields.io/github/release/takanome-dev/assign-issue-action?color=%2330C151"></a>
+    <a href="https://github.com/takanome-dev/assign-issue-action">
+        <img alt="GitHub Actions status" src="https://github.com/takanome-dev/assign-issue-action/actions/workflows/development.yml/badge.svg">
+    </a>
+    <a href="https://github.com/takanome-dev/assign-issue-action">
+        <img alt="GitHub Actions status" src="https://github.com/takanome-dev/assign-issue-action/actions/workflows/codeql-analysis.yml/badge.svg">
+    </a>
+    <a href="https://codecov.io/gh/takanome-dev/assign-issue-action" >
+     <img src="https://codecov.io/gh/takanome-dev/assign-issue-action/branch/edge/graph/badge.svg?token=MX3SB0GFB3"/>
+     </a>
+</p>
 
 <p align="center">
   <img src="public/og.png" alt="Assign Issue Action" width="1200" />

--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ inputs:
       Hi @{{ handle }}, this issue is currently assigned to @{{ assignee }}.
 
       > [!NOTE]
-      > If no progress is made within **{{ total_days }} days**, the issue will be automatically unassigned.
+      > If no progress is made within **{{ days_remaining }} days**, the issue will be automatically unassigned.
 
       <details>
       <summary>Options for contributors</summary>

--- a/commands/__tests__/self-assign.command.test.ts
+++ b/commands/__tests__/self-assign.command.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { SelfAssignCommand } from '../self-assign.command'
+
+const mockCreateComment = mock(() => Promise.resolve())
+const mockAssignWithLabel = mock(() => Promise.resolve())
+const mockGetComments = mock(() => Promise.resolve([]))
+const mockGetAssignmentCount = mock(() => Promise.resolve(0))
+const mockGetAssignmentCountPerLabel = mock(() => Promise.resolve(new Map()))
+const mockSearchIssues = mock(() => Promise.resolve({ total_count: 0, items: [] }))
+const mockIsNewcomer = mock(() => Promise.resolve(false))
+const mockInfo = mock(() => {})
+const mockSetOutput = mock(() => {})
+
+mock.module('@actions/core', () => ({
+  info: mockInfo,
+  setOutput: mockSetOutput,
+}))
+
+describe('SelfAssignCommand', () => {
+  let command: SelfAssignCommand
+
+  beforeEach(() => {
+    command = new SelfAssignCommand()
+    mockCreateComment.mockClear()
+    mockAssignWithLabel.mockClear()
+    mockGetComments.mockClear()
+    mockInfo.mockClear()
+    mockSetOutput.mockClear()
+  })
+
+  describe('already assigned handling', () => {
+    it('should stay silent when user is already assigned to themselves (issue #405)', async () => {
+      const context = {
+        issue: {
+          number: 123,
+          state: 'open',
+          assignee: { login: 'user1' },
+          assignees: [{ login: 'user1' }],
+          user: { login: 'issue-author' },
+          labels: [],
+          updated_at: new Date().toISOString(),
+        },
+        comment: { user: { login: 'user1' } },
+        config: {
+          githubToken: 'test-token',
+          selfAssignCmd: '/assign-me',
+          selfUnassignCmd: '/unassign-me',
+          assignUserCmd: '/assign',
+          unassignUserCmd: '/unassign',
+          assignedLabel: '📍 Assigned',
+          requiredLabel: '',
+          pinLabel: '📌 Pinned',
+          staleAssignmentLabel: '',
+          daysUntilUnassign: 14,
+          maintainers: [],
+          enableAutoSuggestion: false,
+          allowSelfAssignAuthor: true,
+          blockAssignment: false,
+          maxAssignments: 3,
+          maxOverallAssignmentLabels: [],
+          maxOverallAssignmentCount: 0,
+          enableReminder: false,
+          reminderDays: 'auto',
+          assignedComment: 'Assigned!',
+          assignedCommentNewcomer: 'Welcome!',
+          unassignedComment: 'Unassigned @{{handle}}',
+          alreadyAssignedComment: 'Already assigned',
+          alreadyAssignedCommentPinned: 'Already assigned (pinned)',
+          assignmentSuggestionComment: 'Use /assign-me',
+          blockAssignmentComment: 'Blocked',
+          reminderComment: 'Reminder!',
+          maxAssignmentsMessage: 'Max reached',
+          maxOverallAssignmentMessage: 'Label limit',
+          selfAssignAuthorBlockedComment: 'Blocked',
+          ignoredUsers: [],
+          ignoredMessage: '',
+          closedIssueAssignmentComment: '',
+        },
+        repoOwner: 'test-owner',
+        repoName: 'test-repo',
+      }
+
+      const services = {
+        issueService: {
+          assignWithLabel: mockAssignWithLabel,
+          getComments: mockGetComments,
+          getAssignmentCount: mockGetAssignmentCount,
+          getAssignmentCountPerLabel: mockGetAssignmentCountPerLabel,
+          searchIssues: mockSearchIssues,
+        },
+        commentService: {
+          createTemplatedComment: mockCreateComment,
+          renderTemplate: (template: string, data: Record<string, unknown>) =>
+            template.replace(/\{\{(\w+)\}\}/g, (_, key) => String(data[key] || '')),
+        },
+        teamService: {} as any,
+        validator: {
+          validateAssignment: () =>
+            Promise.resolve({
+              valid: false,
+              reason: 'Issue #123 is already assigned to @user1',
+            }),
+          isIssuePinned: () => false,
+        } as any,
+        newcomerChecker: {
+          isNewcomer: mockIsNewcomer,
+        },
+      }
+
+      const result = await command.execute(context as any, services as any)
+
+      // Should succeed (user is already assigned)
+      expect(result.success).toBe(true)
+      // Should NOT post any comment
+      expect(mockCreateComment).not.toHaveBeenCalled()
+      // Should log info message
+      expect(mockInfo).toHaveBeenCalledWith(
+        expect.stringContaining('already assigned'),
+      )
+    })
+
+    it('should post "already assigned" comment when DIFFERENT user tries to assign', async () => {
+      const context = {
+        issue: {
+          number: 123,
+          state: 'open',
+          assignee: { login: 'user2' },
+          assignees: [{ login: 'user2' }],
+          user: { login: 'issue-author' },
+          labels: [],
+          updated_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(), // 7 days ago
+        },
+        comment: { user: { login: 'user1' } },
+        config: {
+          githubToken: 'test-token',
+          selfAssignCmd: '/assign-me',
+          selfUnassignCmd: '/unassign-me',
+          assignUserCmd: '/assign',
+          unassignUserCmd: '/unassign',
+          assignedLabel: '📍 Assigned',
+          requiredLabel: '',
+          pinLabel: '📌 Pinned',
+          staleAssignmentLabel: '',
+          daysUntilUnassign: 14,
+          maintainers: [],
+          enableAutoSuggestion: false,
+          allowSelfAssignAuthor: true,
+          blockAssignment: false,
+          maxAssignments: 3,
+          maxOverallAssignmentLabels: [],
+          maxOverallAssignmentCount: 0,
+          enableReminder: false,
+          reminderDays: 'auto',
+          assignedComment: 'Assigned!',
+          assignedCommentNewcomer: 'Welcome!',
+          unassignedComment: 'Unassigned @{{handle}}',
+          alreadyAssignedComment: 'Already assigned to @{{assignee}}',
+          alreadyAssignedCommentPinned: 'Already assigned (pinned)',
+          assignmentSuggestionComment: 'Use /assign-me',
+          blockAssignmentComment: 'Blocked',
+          reminderComment: 'Reminder!',
+          maxAssignmentsMessage: 'Max reached',
+          maxOverallAssignmentMessage: 'Label limit',
+          selfAssignAuthorBlockedComment: 'Blocked',
+          ignoredUsers: [],
+          ignoredMessage: '',
+          closedIssueAssignmentComment: '',
+        },
+        repoOwner: 'test-owner',
+        repoName: 'test-repo',
+      }
+
+      const services = {
+        issueService: {
+          assignWithLabel: mockAssignWithLabel,
+          getComments: mockGetComments,
+          getAssignmentCount: mockGetAssignmentCount,
+          getAssignmentCountPerLabel: mockGetAssignmentCountPerLabel,
+          searchIssues: mockSearchIssues,
+        },
+        commentService: {
+          createTemplatedComment: mockCreateComment,
+          renderTemplate: (template: string, data: Record<string, unknown>) =>
+            template.replace(/\{\{(\w+)\}\}/g, (_, key) => String(data[key] || '')),
+        },
+        teamService: {} as any,
+        validator: {
+          validateAssignment: () =>
+            Promise.resolve({
+              valid: false,
+              reason: 'Issue #123 is already assigned to @user2',
+            }),
+          isIssuePinned: () => false,
+        } as any,
+        newcomerChecker: {
+          isNewcomer: mockIsNewcomer,
+        },
+      }
+
+      const result = await command.execute(context as any, services as any)
+
+      // Should fail (different user can't assign)
+      expect(result.success).toBe(false)
+      // SHOULD post "already assigned" comment
+      expect(mockCreateComment).toHaveBeenCalled()
+    })
+  })
+})

--- a/commands/__tests__/self-assign.command.test.ts
+++ b/commands/__tests__/self-assign.command.test.ts
@@ -6,7 +6,9 @@ const mockAssignWithLabel = mock(() => Promise.resolve())
 const mockGetComments = mock(() => Promise.resolve([]))
 const mockGetAssignmentCount = mock(() => Promise.resolve(0))
 const mockGetAssignmentCountPerLabel = mock(() => Promise.resolve(new Map()))
-const mockSearchIssues = mock(() => Promise.resolve({ total_count: 0, items: [] }))
+const mockSearchIssues = mock(() =>
+  Promise.resolve({ total_count: 0, items: [] }),
+)
 const mockIsNewcomer = mock(() => Promise.resolve(false))
 const mockInfo = mock(() => {})
 const mockSetOutput = mock(() => {})
@@ -91,7 +93,9 @@ describe('SelfAssignCommand', () => {
         commentService: {
           createTemplatedComment: mockCreateComment,
           renderTemplate: (template: string, data: Record<string, unknown>) =>
-            template.replace(/\{\{(\w+)\}\}/g, (_, key) => String(data[key] || '')),
+            template.replace(/\{\{(\w+)\}\}/g, (_, key) =>
+              String(data[key] || ''),
+            ),
         },
         teamService: {} as any,
         validator: {
@@ -128,7 +132,9 @@ describe('SelfAssignCommand', () => {
           assignees: [{ login: 'user2' }],
           user: { login: 'issue-author' },
           labels: [],
-          updated_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(), // 7 days ago
+          updated_at: new Date(
+            Date.now() - 7 * 24 * 60 * 60 * 1000,
+          ).toISOString(), // 7 days ago
         },
         comment: { user: { login: 'user1' } },
         config: {
@@ -181,7 +187,9 @@ describe('SelfAssignCommand', () => {
         commentService: {
           createTemplatedComment: mockCreateComment,
           renderTemplate: (template: string, data: Record<string, unknown>) =>
-            template.replace(/\{\{(\w+)\}\}/g, (_, key) => String(data[key] || '')),
+            template.replace(/\{\{(\w+)\}\}/g, (_, key) =>
+              String(data[key] || ''),
+            ),
         },
         teamService: {} as any,
         validator: {

--- a/commands/self-assign.command.ts
+++ b/commands/self-assign.command.ts
@@ -65,15 +65,29 @@ export class SelfAssignCommand implements Command {
           ? config.alreadyAssignedCommentPinned
           : config.alreadyAssignedComment
 
-        await commentService.createTemplatedComment(
+        // Check if we already posted an "already assigned" comment recently
+        const hasRecentComment = await this._hasRecentAlreadyAssignedComment(
+          issueService,
           Number(issue?.number),
+          username,
           template,
-          {
-            total_days: String(config.daysUntilUnassign),
-            handle: username,
-            assignee: issue?.assignee?.login,
-          },
         )
+
+        if (!hasRecentComment) {
+          await commentService.createTemplatedComment(
+            Number(issue?.number),
+            template,
+            {
+              total_days: String(config.daysUntilUnassign),
+              handle: username,
+              assignee: issue?.assignee?.login,
+            },
+          )
+        } else {
+          core.info(
+            `🤖 Skipping "already assigned" comment - already posted recently for issue #${issue?.number}`,
+          )
+        }
       } else if (validation.reason?.includes('was previously unassigned')) {
         await commentService.createTemplatedComment(
           Number(issue?.number),
@@ -150,6 +164,49 @@ export class SelfAssignCommand implements Command {
     return {
       success: true,
       message: `Assigned @${username} to issue #${issue?.number}`,
+    }
+  }
+
+  /**
+   * Check if we already posted an "already assigned" comment recently
+   * to avoid repetitive comments when users keep trying to assign themselves
+   */
+  private async _hasRecentAlreadyAssignedComment(
+    issueService: CommandServices['issueService'],
+    issueNumber: number,
+    username: string,
+    template: string,
+  ): Promise<boolean> {
+    try {
+      const comments = await issueService.getComments(issueNumber)
+
+      // Look for a recent comment from the bot mentioning this user and "already assigned"
+      const recentThreshold = new Date()
+      recentThreshold.setDate(recentThreshold.getDate() - 1) // Within last 24 hours
+
+      return comments.some((comment) => {
+        const commentDate = comment.body?.includes('already assigned')
+          ? new Date(comment.created_at || Date.now())
+          : null
+        if (!commentDate) return false
+
+        // Check if comment is recent and mentions this user
+        const isRecent = commentDate > recentThreshold
+        const mentionsUser = comment.body?.includes(`@${username}`)
+        const isAlreadyAssignedComment =
+          comment.body?.includes('already assigned') ||
+          template
+            .split('\n')[0]
+            .trim()
+            .split(' ')
+            .slice(0, 3)
+            .every((word) => comment.body?.includes(word))
+
+        return isRecent && mentionsUser && isAlreadyAssignedComment
+      })
+    } catch {
+      // If we can't fetch comments, assume no recent comment to be safe
+      return false
     }
   }
 }

--- a/commands/self-assign.command.ts
+++ b/commands/self-assign.command.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core'
-import { add, format } from 'date-fns'
+import { add, format, differenceInDays } from 'date-fns'
 import type {
   Command,
   CommandContext,
@@ -74,11 +74,23 @@ export class SelfAssignCommand implements Command {
         )
 
         if (!hasRecentComment) {
+          // Calculate remaining days based on last activity
+          // Issue updated_at reflects last comment/activity
+          const lastActivity = issue?.updated_at
+            ? new Date(issue.updated_at)
+            : new Date()
+          const daysSinceActivity = differenceInDays(new Date(), lastActivity)
+          const daysRemaining = Math.max(
+            0,
+            config.daysUntilUnassign - daysSinceActivity,
+          )
+
           await commentService.createTemplatedComment(
             Number(issue?.number),
             template,
             {
               total_days: String(config.daysUntilUnassign),
+              days_remaining: daysRemaining,
               handle: username,
               assignee: issue?.assignee?.login,
             },

--- a/commands/self-assign.command.ts
+++ b/commands/self-assign.command.ts
@@ -57,6 +57,20 @@ export class SelfAssignCommand implements Command {
           { handle: username },
         )
       } else if (validation.reason?.includes('already assigned')) {
+        const currentAssignee = issue?.assignee?.login
+
+        // If the user trying to assign is the current assignee, stay silent (issue #405)
+        if (currentAssignee === username) {
+          core.info(
+            `🤖 User @${username} is already assigned to issue #${issue?.number}, staying silent`,
+          )
+          core.setOutput('assigned', 'no')
+          return {
+            success: true,
+            message: `User @${username} is already assigned to issue #${issue?.number}`,
+          }
+        }
+
         const isPinned = validator.isIssuePinned({
           labels: issue?.labels,
           number: Number(issue?.number),
@@ -92,7 +106,7 @@ export class SelfAssignCommand implements Command {
               total_days: String(config.daysUntilUnassign),
               days_remaining: daysRemaining,
               handle: username,
-              assignee: issue?.assignee?.login,
+              assignee: currentAssignee,
             },
           )
         } else {

--- a/commands/self-unassign.command.ts
+++ b/commands/self-unassign.command.ts
@@ -12,7 +12,7 @@ export class SelfUnassignCommand implements Command {
     services: CommandServices,
   ): Promise<CommandResult> {
     const { issue, comment, config } = context
-    const { issueService, commentService } = services
+    const { issueService, commentService, validator } = services
 
     const commenterLogin = comment?.user?.login
     const assigneeLogin = issue?.assignee?.login
@@ -33,6 +33,15 @@ export class SelfUnassignCommand implements Command {
       }
     }
 
+    // Generate unassign comment with hidden marker for tracking
+    const unassignBody = validator.getUnassignCommentBody(
+      config.unassignedComment,
+      {
+        handle: commenterLogin,
+        pin_label: config.pinLabel,
+      },
+    )
+
     // Unassign and post comment
     await Promise.all([
       issueService.unassignWithLabels(Number(issue?.number), assigneeLogin, [
@@ -40,14 +49,7 @@ export class SelfUnassignCommand implements Command {
         config.pinLabel,
         '🔔 reminder-sent',
       ]),
-      commentService.createTemplatedComment(
-        Number(issue?.number),
-        config.unassignedComment,
-        {
-          handle: commenterLogin,
-          pin_label: config.pinLabel,
-        },
-      ),
+      commentService.createComment(Number(issue?.number), unassignBody),
     ])
 
     core.info(`🤖 Done issue unassignment!`)

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -58370,11 +58370,12 @@ var SelfAssignCommand = class {
 					labels: issue?.labels,
 					number: Number(issue?.number)
 				}) ? config.alreadyAssignedCommentPinned : config.alreadyAssignedComment;
-				await commentService.createTemplatedComment(Number(issue?.number), template, {
+				if (!await this._hasRecentAlreadyAssignedComment(issueService, Number(issue?.number), username, template)) await commentService.createTemplatedComment(Number(issue?.number), template, {
 					total_days: String(config.daysUntilUnassign),
 					handle: username,
 					assignee: issue?.assignee?.login
 				});
+				else _actions_core.info(`🤖 Skipping "already assigned" comment - already posted recently for issue #${issue?.number}`);
 			} else if (validation.reason?.includes("was previously unassigned")) await commentService.createTemplatedComment(Number(issue?.number), config.blockAssignmentComment, { handle: username });
 			else if (validation.reason?.includes("maximum number of assignments")) await commentService.createTemplatedComment(Number(issue?.number), config.maxAssignmentsMessage, {
 				handle: username,
@@ -58411,6 +58412,27 @@ var SelfAssignCommand = class {
 			success: true,
 			message: `Assigned @${username} to issue #${issue?.number}`
 		};
+	}
+	/**
+	* Check if we already posted an "already assigned" comment recently
+	* to avoid repetitive comments when users keep trying to assign themselves
+	*/
+	async _hasRecentAlreadyAssignedComment(issueService, issueNumber, username, template) {
+		try {
+			const comments = await issueService.getComments(issueNumber);
+			const recentThreshold = /* @__PURE__ */ new Date();
+			recentThreshold.setDate(recentThreshold.getDate() - 1);
+			return comments.some((comment) => {
+				const commentDate = comment.body?.includes("already assigned") ? new Date(comment.created_at || Date.now()) : null;
+				if (!commentDate) return false;
+				const isRecent = commentDate > recentThreshold;
+				const mentionsUser = comment.body?.includes(`@${username}`);
+				const isAlreadyAssignedComment = comment.body?.includes("already assigned") || template.split("\n")[0].trim().split(" ").slice(0, 3).every((word) => comment.body?.includes(word));
+				return isRecent && mentionsUser && isAlreadyAssignedComment;
+			});
+		} catch {
+			return false;
+		}
 	}
 };
 
@@ -59066,6 +59088,7 @@ var ScheduleHandler = class {
 		this.commentService = new CommentService(this.octokit, repoContext);
 	}
 	async handle_unassignments() {
+		await this._cleanup_orphaned_labels();
 		const { unassignIssues, reminderIssues } = await this._get_assigned_issues();
 		let processedUnassignments = [];
 		let processedReminders = [];
@@ -59076,6 +59099,35 @@ var ScheduleHandler = class {
 		}
 		if (reminderIssues.length > 0) processedReminders = await this._process_reminders(reminderIssues);
 		await this._generate_summary(processedUnassignments, processedReminders);
+	}
+	/**
+	* Find issues with assigned label but no assignee and remove the label
+	* This handles cases where users were manually unassigned or deleted their profile
+	*/
+	async _cleanup_orphaned_labels() {
+		const { owner, repo } = this.context.repo;
+		const { assignedLabel, pinLabel } = this.config;
+		const { data: { items: orphanedIssues } } = await this.octokit.request("GET /search/issues", {
+			q: `repo:${owner}/${repo} is:issue is:open label:"${assignedLabel}" -label:"${pinLabel}" no:assignee`,
+			per_page: 100,
+			advanced_search: "true",
+			headers: { "X-GitHub-Api-Version": "2022-11-28" }
+		});
+		if (orphanedIssues.length === 0) return;
+		_actions_core.info(`🧹 Found ${orphanedIssues.length} issues with orphaned assigned labels (no assignee)`);
+		const chunks = chunkArray(orphanedIssues, 5);
+		for (let i = 0; i < chunks.length; i++) {
+			const chunk = chunks[i];
+			await Promise.allSettled(chunk.map(async (issue) => {
+				try {
+					await this.issueService.removeLabel(issue.number, assignedLabel);
+					_actions_core.info(`🧹 Removed orphaned assigned label from issue #${issue.number}`);
+				} catch (err) {
+					_actions_core.warning(`⚠️ Failed to remove label from issue #${issue.number}: ${err}`);
+				}
+			}));
+			if (i < chunks.length - 1) await new Promise((resolve) => setTimeout(resolve, 1e3));
+		}
 	}
 	async _get_assigned_issues() {
 		const { owner, repo } = this.context.repo;

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -58366,16 +58366,30 @@ var SelfAssignCommand = class {
 			else if (validation.reason?.includes("ignored users list")) await commentService.createTemplatedComment(Number(issue?.number), config.ignoredMessage, { handle: username });
 			else if (validation.reason?.includes("cannot self-assign their own issue")) await commentService.createTemplatedComment(Number(issue?.number), config.selfAssignAuthorBlockedComment, { handle: username });
 			else if (validation.reason?.includes("already assigned")) {
+				const currentAssignee = issue?.assignee?.login;
+				if (currentAssignee === username) {
+					_actions_core.info(`🤖 User @${username} is already assigned to issue #${issue?.number}, staying silent`);
+					_actions_core.setOutput("assigned", "no");
+					return {
+						success: true,
+						message: `User @${username} is already assigned to issue #${issue?.number}`
+					};
+				}
 				const template = validator.isIssuePinned({
 					labels: issue?.labels,
 					number: Number(issue?.number)
 				}) ? config.alreadyAssignedCommentPinned : config.alreadyAssignedComment;
-				if (!await this._hasRecentAlreadyAssignedComment(issueService, Number(issue?.number), username, template)) await commentService.createTemplatedComment(Number(issue?.number), template, {
-					total_days: String(config.daysUntilUnassign),
-					handle: username,
-					assignee: issue?.assignee?.login
-				});
-				else _actions_core.info(`🤖 Skipping "already assigned" comment - already posted recently for issue #${issue?.number}`);
+				if (!await this._hasRecentAlreadyAssignedComment(issueService, Number(issue?.number), username, template)) {
+					const lastActivity = issue?.updated_at ? new Date(issue.updated_at) : /* @__PURE__ */ new Date();
+					const daysSinceActivity = (0, date_fns.differenceInDays)(/* @__PURE__ */ new Date(), lastActivity);
+					const daysRemaining = Math.max(0, config.daysUntilUnassign - daysSinceActivity);
+					await commentService.createTemplatedComment(Number(issue?.number), template, {
+						total_days: String(config.daysUntilUnassign),
+						days_remaining: daysRemaining,
+						handle: username,
+						assignee: currentAssignee
+					});
+				} else _actions_core.info(`🤖 Skipping "already assigned" comment - already posted recently for issue #${issue?.number}`);
 			} else if (validation.reason?.includes("was previously unassigned")) await commentService.createTemplatedComment(Number(issue?.number), config.blockAssignmentComment, { handle: username });
 			else if (validation.reason?.includes("maximum number of assignments")) await commentService.createTemplatedComment(Number(issue?.number), config.maxAssignmentsMessage, {
 				handle: username,
@@ -58441,7 +58455,7 @@ var SelfAssignCommand = class {
 var SelfUnassignCommand = class {
 	async execute(context$3, services) {
 		const { issue, comment, config } = context$3;
-		const { issueService, commentService } = services;
+		const { issueService, commentService, validator } = services;
 		const commenterLogin = comment?.user?.login;
 		const assigneeLogin = issue?.assignee?.login;
 		_actions_core.info(`🤖 Starting issue #${issue?.number} unassignment for user @${assigneeLogin} in repo "${context$3.repoOwner}/${context$3.repoName}"`);
@@ -58458,14 +58472,15 @@ var SelfUnassignCommand = class {
 				}
 			};
 		}
+		const unassignBody = validator.getUnassignCommentBody(config.unassignedComment, {
+			handle: commenterLogin,
+			pin_label: config.pinLabel
+		});
 		await Promise.all([issueService.unassignWithLabels(Number(issue?.number), assigneeLogin, [
 			config.assignedLabel,
 			config.pinLabel,
 			"🔔 reminder-sent"
-		]), commentService.createTemplatedComment(Number(issue?.number), config.unassignedComment, {
-			handle: commenterLogin,
-			pin_label: config.pinLabel
-		})]);
+		]), commentService.createComment(Number(issue?.number), unassignBody)]);
 		_actions_core.info(`🤖 Done issue unassignment!`);
 		_actions_core.setOutput("unassigned", "yes");
 		_actions_core.setOutput("unassigned_issues", [issue?.number]);
@@ -58706,20 +58721,37 @@ var AssignmentValidator = class {
 		};
 	}
 	/**
+	* Generate hidden HTML comment marker for unassignment tracking
+	* This survives template customizations and is machine-readable
+	*/
+	getUnassignMarker(username) {
+		return `<!-- unassigned:${username} -->`;
+	}
+	/**
 	* Check if user was previously unassigned and is blocked from reassignment
 	*/
 	async wasBlockedFromReassignment(issueNumber, username) {
 		const { blockAssignment, unassignUserCmd, unassignedComment } = this.config;
 		if (!blockAssignment) return { valid: true };
-		const wasUnassigned = (await this.issueService.getComments(issueNumber)).some((comment) => {
+		const comments = await this.issueService.getComments(issueNumber);
+		const marker = this.getUnassignMarker(username);
+		const wasUnassigned = comments.some((comment) => {
+			const hasMarker = comment.body?.includes(marker);
 			const hasManualUnassign = comment.body?.includes(`${unassignUserCmd} @${username}`);
-			const hasAutoUnassign = comment.body?.includes(mustache.default.render(unassignedComment, { handle: username }));
-			return hasManualUnassign || hasAutoUnassign;
+			const hasRenderedComment = comment.body?.includes(mustache.default.render(unassignedComment, { handle: username }));
+			return hasMarker || hasManualUnassign || hasRenderedComment;
 		});
 		return {
 			valid: !wasUnassigned,
 			reason: wasUnassigned ? `User @${username} was previously unassigned from issue #${issueNumber}` : void 0
 		};
+	}
+	/**
+	* Get the unassign comment body with hidden marker for tracking
+	*/
+	getUnassignCommentBody(template, data) {
+		const marker = this.getUnassignMarker(data.handle);
+		return `${mustache.default.render(template, data)}\n${marker}`;
 	}
 	/**
 	* Check if user has reached max assignment count
@@ -59152,9 +59184,7 @@ var ScheduleHandler = class {
 			}));
 			for (const result of results.filter(Boolean)) {
 				const hasReminderLabel = result.issue?.labels?.some((label) => label?.name === "🔔 reminder-sent");
-				let shouldUnassign = result.daysSinceActivity >= daysUntilUnassign;
-				if (hasReminderLabel) shouldUnassign = shouldUnassign || result.daysSinceActivity >= daysUntilUnassign - reminderDays;
-				if (shouldUnassign) {
+				if (result.daysSinceActivity >= daysUntilUnassign) {
 					unassignIssues.push({
 						...result,
 						hasReminderLabel
@@ -59230,14 +59260,15 @@ var ScheduleHandler = class {
 	}
 	async _unassign_issue(issue) {
 		if (!issue.assignee) {
-			_actions_core.warning(`⚠️ Issue #${issue.number} has no assignee, skipping...`);
+			_actions_core.info(`📋 Issue #${issue.number} already unassigned, skipping...`);
 			return;
 		}
 		const { unassignedComment, pinLabel, assignedLabel } = this.config;
-		const body = this.commentService.renderTemplate(unassignedComment, {
+		const marker = `<!-- unassigned:${issue.assignee.login} -->`;
+		const body = `${this.commentService.renderTemplate(unassignedComment, {
 			handle: issue.assignee.login,
 			pin_label: pinLabel
-		});
+		})}\n${marker}`;
 		await this.issueService.unassignWithLabels(issue.number, issue.assignee.login, [
 			assignedLabel,
 			pinLabel,
@@ -59246,10 +59277,14 @@ var ScheduleHandler = class {
 		await this.commentService.createComment(issue.number, body);
 	}
 	async _send_reminder_for_issue(issue, daysSinceActivity) {
+		if (!issue.assignee) {
+			_actions_core.info(`🔔 Skipping reminder for issue #${issue.number} - no longer assigned`);
+			return;
+		}
 		const { daysUntilUnassign, reminderComment, pinLabel } = this.config;
 		const daysRemaining = Math.max(0, daysUntilUnassign - daysSinceActivity);
 		const body = this.commentService.renderTemplate(reminderComment, {
-			handle: issue.assignee?.login,
+			handle: issue.assignee.login,
 			days_remaining: daysRemaining,
 			pin_label: pinLabel
 		});

--- a/handlers/__tests__/schedule-handler.test.ts
+++ b/handlers/__tests__/schedule-handler.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'bun:test'
+
+describe('ScheduleHandler reminder logic', () => {
+  describe('unassignment deadline', () => {
+    it('should NOT unassign early when reminder was sent but user responded (issue #412)', () => {
+      // Scenario from issue #412:
+      // days_until_unassign = 30, reminder_days = 7
+      // Day 24: Reminder sent
+      // Day 24+: User responds (activity resets to 0)
+      // Should NOT unassign until day 30 of ACTUAL inactivity
+
+      const daysUntilUnassign = 30
+      const reminderDays = 7
+      const daysSinceActivity = 23
+      const hasReminderLabel = true
+
+      // The FIXED logic: only check against daysUntilUnassign
+      const shouldUnassignFixed = daysSinceActivity >= daysUntilUnassign
+
+      // Should be false - not ready to unassign yet
+      expect(shouldUnassignFixed).toBe(false)
+
+      // The BUGGY logic (old implementation):
+      const shouldUnassignBuggy =
+        daysSinceActivity >= daysUntilUnassign ||
+        (hasReminderLabel && daysSinceActivity >= daysUntilUnassign - reminderDays)
+
+      // This incorrectly returns true (23 >= 23)
+      expect(shouldUnassignBuggy).toBe(true)
+    })
+
+    it('should unassign exactly at daysUntilUnassign days of inactivity', () => {
+      const daysUntilUnassign = 14
+
+      // At 13 days - should NOT unassign
+      expect(13 >= daysUntilUnassign).toBe(false)
+
+      // At 14 days - should unassign
+      expect(14 >= daysUntilUnassign).toBe(true)
+
+      // At 15 days - should unassign
+      expect(15 >= daysUntilUnassign).toBe(true)
+    })
+
+    it('should handle edge case: reminder sent at exact reminderDays threshold', () => {
+      const daysUntilUnassign = 30
+      const reminderDays = 15 // auto-calculated as floor(30/2)
+
+      // User active for 15 days, gets reminder
+      // User responds immediately, activity resets
+      // Should get full 30 days from response, not 15
+
+      const daysSinceResponse = 20 // 20 days since user responded
+      const shouldUnassign = daysSinceResponse >= daysUntilUnassign
+
+      expect(shouldUnassign).toBe(false) // 20 < 30, don't unassign
+    })
+  })
+
+  describe('reminder timing', () => {
+    it('should send reminder when daysSinceActivity >= reminderDays', () => {
+      const reminderDays = 7
+
+      // At 6 days - should NOT send reminder
+      expect(6 >= reminderDays).toBe(false)
+
+      // At 7 days - should send reminder
+      expect(7 >= reminderDays).toBe(true)
+
+      // At 10 days - should send reminder
+      expect(10 >= reminderDays).toBe(true)
+    })
+
+    it('should correctly calculate days_remaining for reminder message', () => {
+      const daysUntilUnassign = 30
+
+      // Reminder sent at day 15
+      const daysSinceActivity = 15
+      const daysRemaining = Math.max(0, daysUntilUnassign - daysSinceActivity)
+
+      expect(daysRemaining).toBe(15)
+    })
+
+    it('should handle auto-calculated reminder days', () => {
+      const daysUntilUnassign = 30
+      const autoReminderDays = Math.floor(daysUntilUnassign / 2)
+
+      expect(autoReminderDays).toBe(15)
+    })
+  })
+
+  describe('reminder label behavior', () => {
+    it('should NOT send duplicate reminders when reminder label exists', () => {
+      const hasReminderLabel = true
+      const daysSinceActivity = 20
+      const reminderDays = 7
+
+      // Should NOT send another reminder if label already present
+      const shouldSendReminder =
+        daysSinceActivity >= reminderDays && !hasReminderLabel
+
+      expect(shouldSendReminder).toBe(false)
+    })
+
+    it('should send reminder when threshold reached and no label exists', () => {
+      const hasReminderLabel = false
+      const daysSinceActivity = 10
+      const reminderDays = 7
+
+      const shouldSendReminder =
+        daysSinceActivity >= reminderDays && !hasReminderLabel
+
+      expect(shouldSendReminder).toBe(true)
+    })
+  })
+})

--- a/handlers/__tests__/schedule-handler.test.ts
+++ b/handlers/__tests__/schedule-handler.test.ts
@@ -23,7 +23,8 @@ describe('ScheduleHandler reminder logic', () => {
       // The BUGGY logic (old implementation):
       const shouldUnassignBuggy =
         daysSinceActivity >= daysUntilUnassign ||
-        (hasReminderLabel && daysSinceActivity >= daysUntilUnassign - reminderDays)
+        (hasReminderLabel &&
+          daysSinceActivity >= daysUntilUnassign - reminderDays)
 
       // This incorrectly returns true (23 >= 23)
       expect(shouldUnassignBuggy).toBe(true)

--- a/handlers/schedule-handler.ts
+++ b/handlers/schedule-handler.ts
@@ -181,15 +181,7 @@ export default class ScheduleHandler {
           (label) => label?.name === '🔔 reminder-sent',
         )
 
-        let shouldUnassign = result.daysSinceActivity >= daysUntilUnassign
-        if (hasReminderLabel) {
-          shouldUnassign =
-            shouldUnassign ||
-            // The last day of activity is (normally) the point in time where the reminder label was sent.
-            // Thus, reminderDays already passed of the number of daysUntilUnassign.
-            // Therefore, we substract reminderDays from daysUntilUnassign to know the "real" period to wait for.
-            result.daysSinceActivity >= daysUntilUnassign - reminderDays
-        }
+        const shouldUnassign = result.daysSinceActivity >= daysUntilUnassign
         if (shouldUnassign) {
           unassignIssues.push({ ...result, hasReminderLabel })
           continue

--- a/handlers/schedule-handler.ts
+++ b/handlers/schedule-handler.ts
@@ -283,10 +283,12 @@ export default class ScheduleHandler {
 
     const { unassignedComment, pinLabel, assignedLabel } = this.config
 
-    const body = this.commentService.renderTemplate(unassignedComment, {
+    // Generate hidden marker for tracking this unassignment
+    const marker = `<!-- unassigned:${issue.assignee.login} -->`
+    const body = `${this.commentService.renderTemplate(unassignedComment, {
       handle: issue.assignee.login,
       pin_label: pinLabel,
-    })
+    })}\n${marker}`
 
     // Unassign and remove labels in parallel, then post comment
     await this.issueService.unassignWithLabels(

--- a/handlers/schedule-handler.ts
+++ b/handlers/schedule-handler.ts
@@ -46,6 +46,9 @@ export default class ScheduleHandler {
   }
 
   async handle_unassignments(): Promise<void> {
+    // First, clean up orphaned assigned labels (issues with assigned label but no assignee)
+    await this._cleanup_orphaned_labels()
+
     // Get all assigned issues with their activity status in a single query
     const { unassignIssues, reminderIssues } = await this._get_assigned_issues()
 
@@ -70,6 +73,62 @@ export default class ScheduleHandler {
 
     // Generate the markdown summary
     await this._generate_summary(processedUnassignments, processedReminders)
+  }
+
+  /**
+   * Find issues with assigned label but no assignee and remove the label
+   * This handles cases where users were manually unassigned or deleted their profile
+   */
+  private async _cleanup_orphaned_labels(): Promise<void> {
+    const { owner, repo } = this.context.repo
+    const { assignedLabel, pinLabel } = this.config
+
+    // Fetch issues with assigned label but no assignee
+    const {
+      data: { items: orphanedIssues },
+    } = await this.octokit.request('GET /search/issues', {
+      q: `repo:${owner}/${repo} is:issue is:open label:"${assignedLabel}" -label:"${pinLabel}" no:assignee`,
+      per_page: 100,
+      advanced_search: 'true',
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    })
+
+    if (orphanedIssues.length === 0) {
+      return
+    }
+
+    core.info(
+      `🧹 Found ${orphanedIssues.length} issues with orphaned assigned labels (no assignee)`,
+    )
+
+    // Process in chunks of 5
+    const chunks = chunkArray(orphanedIssues, 5)
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i]
+
+      await Promise.allSettled(
+        chunk.map(async (issue) => {
+          try {
+            await this.issueService.removeLabel(issue.number, assignedLabel)
+            core.info(
+              `🧹 Removed orphaned assigned label from issue #${issue.number}`,
+            )
+          } catch (err) {
+            core.warning(
+              `⚠️ Failed to remove label from issue #${issue.number}: ${err}`,
+            )
+          }
+        }),
+      )
+
+      // Add delay between chunks
+      if (i < chunks.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+      }
+    }
   }
 
   private async _get_assigned_issues() {

--- a/handlers/schedule-handler.ts
+++ b/handlers/schedule-handler.ts
@@ -275,9 +275,7 @@ export default class ScheduleHandler {
   private async _unassign_issue(issue: Issue) {
     if (!issue.assignee) {
       // Issue may have been manually unassigned since we fetched it
-      core.info(
-        `📋 Issue #${issue.number} already unassigned, skipping...`,
-      )
+      core.info(`📋 Issue #${issue.number} already unassigned, skipping...`)
       return
     }
 

--- a/handlers/schedule-handler.ts
+++ b/handlers/schedule-handler.ts
@@ -274,8 +274,10 @@ export default class ScheduleHandler {
 
   private async _unassign_issue(issue: Issue) {
     if (!issue.assignee) {
-      // well, this should never happen anyway :)
-      core.warning(`⚠️ Issue #${issue.number} has no assignee, skipping...`)
+      // Issue may have been manually unassigned since we fetched it
+      core.info(
+        `📋 Issue #${issue.number} already unassigned, skipping...`,
+      )
       return
     }
 
@@ -300,11 +302,19 @@ export default class ScheduleHandler {
     issue: Issue,
     daysSinceActivity: number,
   ) {
+    // Guard: Don't send reminder if issue was unassigned since we fetched it
+    if (!issue.assignee) {
+      core.info(
+        `🔔 Skipping reminder for issue #${issue.number} - no longer assigned`,
+      )
+      return
+    }
+
     const { daysUntilUnassign, reminderComment, pinLabel } = this.config
     const daysRemaining = Math.max(0, daysUntilUnassign - daysSinceActivity)
 
     const body = this.commentService.renderTemplate(reminderComment, {
-      handle: issue.assignee?.login,
+      handle: issue.assignee.login,
       days_remaining: daysRemaining,
       pin_label: pinLabel,
     })

--- a/services/assignment/__tests__/assignment-validator.test.ts
+++ b/services/assignment/__tests__/assignment-validator.test.ts
@@ -158,6 +158,60 @@ describe('AssignmentValidator', () => {
       const result = await validator.wasBlockedFromReassignment(123, 'user1')
       expect(result.valid).toBe(false)
     })
+
+    it('should return invalid when hidden marker exists (issue #410)', async () => {
+      config.blockAssignment = true
+      validator = new AssignmentValidator(mockIssueService, config)
+
+      // Hidden marker format (new, more reliable)
+      mockIssueService.getComments.mockResolvedValueOnce([
+        { body: 'Some comment\n<!-- unassigned:user1 -->' },
+      ])
+
+      const result = await validator.wasBlockedFromReassignment(123, 'user1')
+      expect(result.valid).toBe(false)
+    })
+
+    it('should NOT block User B when User A was unassigned (issue #410)', async () => {
+      config.blockAssignment = true
+      validator = new AssignmentValidator(mockIssueService, config)
+
+      // User A was unassigned
+      mockIssueService.getComments.mockResolvedValueOnce([
+        { body: 'Unassigned @userA' },
+      ])
+
+      // User B tries to assign - should be allowed
+      const result = await validator.wasBlockedFromReassignment(123, 'userB')
+      expect(result.valid).toBe(true)
+    })
+
+    it('should NOT block User B when User A has hidden marker (issue #410)', async () => {
+      config.blockAssignment = true
+      validator = new AssignmentValidator(mockIssueService, config)
+
+      // User A was unassigned with hidden marker
+      mockIssueService.getComments.mockResolvedValueOnce([
+        { body: 'Some comment\n<!-- unassigned:userA -->' },
+      ])
+
+      // User B tries to assign - should be allowed
+      const result = await validator.wasBlockedFromReassignment(123, 'userB')
+      expect(result.valid).toBe(true)
+    })
+
+    it('should detect manual unassign command', async () => {
+      config.blockAssignment = true
+      config.unassignUserCmd = '/unassign'
+      validator = new AssignmentValidator(mockIssueService, config)
+
+      mockIssueService.getComments.mockResolvedValueOnce([
+        { body: '/unassign @user1' },
+      ])
+
+      const result = await validator.wasBlockedFromReassignment(123, 'user1')
+      expect(result.valid).toBe(false)
+    })
   })
 
   describe('hasReachedMaxAssignments', () => {

--- a/services/assignment/assignment-validator.ts
+++ b/services/assignment/assignment-validator.ts
@@ -89,6 +89,14 @@ export class AssignmentValidator {
   }
 
   /**
+   * Generate hidden HTML comment marker for unassignment tracking
+   * This survives template customizations and is machine-readable
+   */
+  private getUnassignMarker(username: string): string {
+    return `<!-- unassigned:${username} -->`
+  }
+
+  /**
    * Check if user was previously unassigned and is blocked from reassignment
    */
   async wasBlockedFromReassignment(
@@ -103,14 +111,21 @@ export class AssignmentValidator {
 
     const comments = await this.issueService.getComments(issueNumber)
 
+    // Look for the hidden HTML marker or other indicators
+    const marker = this.getUnassignMarker(username)
     const wasUnassigned = comments.some((comment) => {
+      // Check 1: Hidden HTML marker (most reliable, new format)
+      const hasMarker = comment.body?.includes(marker)
+      // Check 2: Manual unassign command
       const hasManualUnassign = comment.body?.includes(
         `${unassignUserCmd} @${username}`,
       )
-      const hasAutoUnassign = comment.body?.includes(
+      // Check 3: Backward compatibility - check if rendered template with handle exists
+      // This handles old comments that don't have the hidden marker
+      const hasRenderedComment = comment.body?.includes(
         mustache.render(unassignedComment, { handle: username }),
       )
-      return hasManualUnassign || hasAutoUnassign
+      return hasMarker || hasManualUnassign || hasRenderedComment
     })
 
     return {
@@ -119,6 +134,18 @@ export class AssignmentValidator {
         ? `User @${username} was previously unassigned from issue #${issueNumber}`
         : undefined,
     }
+  }
+
+  /**
+   * Get the unassign comment body with hidden marker for tracking
+   */
+  getUnassignCommentBody(
+    template: string,
+    data: { handle: string; pin_label: string },
+  ): string {
+    const marker = this.getUnassignMarker(data.handle)
+    const renderedComment = mustache.render(template, data)
+    return `${renderedComment}\n${marker}`
   }
 
   /**

--- a/services/github/issue-service.ts
+++ b/services/github/issue-service.ts
@@ -77,7 +77,9 @@ export class IssueService {
     }
   }
 
-  async getComments(issueNumber: number): Promise<Array<{ body?: string }>> {
+  async getComments(
+    issueNumber: number,
+  ): Promise<Array<{ body?: string; created_at?: string }>> {
     const response = await this.octokit.request(
       'GET /repos/{owner}/{repo}/issues/{issue_number}/comments',
       {

--- a/types/comment.ts
+++ b/types/comment.ts
@@ -1,5 +1,6 @@
 export interface AlreadyAssignedCommentArg {
   total_days: string
+  days_remaining: number
   handle: string
   assignee: string
 }


### PR DESCRIPTION
## 🎯 Overview

This PR addresses couple of issues:

- [x] #443 Remove assigned label if no one is assigned
- [x] Repetitive "Already Assigned" Comments
- [x] #412 Early unassignment bug when reminders are sent
- [x] #410 `block_assignment` incorrectly blocks all users after any unassignment, not just the unassigned user
- [x] #405 Added silent check for same-user re-assignment

## 🧪 Testing

- [x] All 95 existing tests pass
- [x] TypeScript compilation succeeds
- [x] Bundle builds successfully

## 🚧 Work in Progress

This PR is part of a larger batch of assignment-related fixes. Additional issues may be included before merging.

---

**Related:** #443, #412, #410, #405
