### PR TITLE
feat: add PR statistics placeholders for assigned_comment

### DIFF
--- a/commands/self-assign.command.ts
+++ b/commands/self-assign.command.ts
@@ -13,8 +13,13 @@ export class SelfAssignCommand implements Command {
     services: CommandServices,
   ): Promise<CommandResult> {
     const { issue, comment, config } = context
-    const { issueService, commentService, validator, newcomerChecker } =
-      services
+    const {
+      issueService,
+      commentService,
+      validator,
+      newcomerChecker,
+      statsService,
+    } = services
     const username = comment?.user?.login
 
     core.info(
@@ -162,6 +167,12 @@ export class SelfAssignCommand implements Command {
       `🤖 User @${username} is ${isNewcomer ? 'a newcomer' : 'a returning contributor'}`,
     )
 
+    // Fetch PR stats for the contributor
+    const stats = await statsService.getContributorStats(username)
+    core.info(
+      `🤖 @${username} has ${stats.prs_total} PRs (${stats.prs_merged} merged, ${stats.prs_merged_percentage}%)`,
+    )
+
     // Assign and post comment
     await Promise.all([
       issueService.assignWithLabel(
@@ -180,6 +191,10 @@ export class SelfAssignCommand implements Command {
           ),
           handle: username,
           pin_label: config.pinLabel,
+          prs_total: stats.prs_total,
+          prs_merged: stats.prs_merged,
+          prs_unmerged: stats.prs_unmerged,
+          prs_merged_percentage: stats.prs_merged_percentage,
         },
       ),
     ])

--- a/commands/types.ts
+++ b/commands/types.ts
@@ -7,6 +7,7 @@ import type {
 import type {
   CommentService,
   IssueService,
+  StatsService,
   TeamService,
 } from '../services/github'
 import type { GhComment, GhIssue } from '../types'
@@ -36,6 +37,7 @@ export interface CommandServices {
   issueService: IssueService
   commentService: CommentService
   teamService: TeamService
+  statsService: StatsService
   validator: AssignmentValidator
   newcomerChecker: NewcomerChecker
 }

--- a/handlers/comment-handler.ts
+++ b/handlers/comment-handler.ts
@@ -25,6 +25,7 @@ import {
   CommentService,
   IssueService,
   type RepoContext,
+  StatsService,
   TeamService,
 } from '../services/github'
 import type { GhComment, GhIssue } from '../types'
@@ -60,6 +61,7 @@ export default class CommentHandler {
       issueService,
       commentService,
       teamService: this.teamService,
+      statsService: new StatsService(this.octokit, repoContext),
       validator: new AssignmentValidator(issueService, this.config),
       newcomerChecker: new NewcomerChecker(issueService),
     }

--- a/services/github/__tests__/stats-service.test.ts
+++ b/services/github/__tests__/stats-service.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, mock, beforeEach } from 'bun:test'
+import { StatsService } from '../stats-service'
+import type { OctokitClient } from '../../../core'
+
+describe('StatsService', () => {
+  let mockOctokit: OctokitClient
+  let statsService: StatsService
+
+  beforeEach(() => {
+    mockOctokit = {
+      request: mock(() => Promise.resolve({ data: { total_count: 0, items: [] } })),
+    } as unknown as OctokitClient
+
+    statsService = new StatsService(mockOctokit, {
+      owner: 'test-owner',
+      repo: 'test-repo',
+    })
+  })
+
+  describe('getContributorStats', () => {
+    it('should return PR stats for a contributor', async () => {
+      // Mock first call (all PRs) returns 5 total
+      // Mock second call (merged PRs) returns 3 merged
+      let callCount = 0
+      mockOctokit.request = mock(() => {
+        callCount++
+        if (callCount === 1) {
+          return Promise.resolve({
+            data: { total_count: 5, items: [{}, {}, {}, {}, {}] },
+          })
+        }
+        return Promise.resolve({
+          data: { total_count: 3, items: [{}, {}, {}] },
+        })
+      }) as unknown as typeof mockOctokit.request
+
+      const stats = await statsService.getContributorStats('testuser')
+
+      expect(stats.prs_total).toBe(5)
+      expect(stats.prs_merged).toBe(3)
+      expect(stats.prs_unmerged).toBe(2)
+      expect(stats.prs_merged_percentage).toBe(60)
+    })
+
+    it('should return zeros for a newcomer with no PRs', async () => {
+      mockOctokit.request = mock(() =>
+        Promise.resolve({
+          data: { total_count: 0, items: [] },
+        }),
+      ) as unknown as typeof mockOctokit.request
+
+      const stats = await statsService.getContributorStats('newuser')
+
+      expect(stats.prs_total).toBe(0)
+      expect(stats.prs_merged).toBe(0)
+      expect(stats.prs_unmerged).toBe(0)
+      expect(stats.prs_merged_percentage).toBe(0)
+    })
+
+    it('should calculate 0% for all unmerged PRs', async () => {
+      let callCount = 0
+      mockOctokit.request = mock(() => {
+        callCount++
+        if (callCount === 1) {
+          return Promise.resolve({
+            data: { total_count: 3, items: [{}, {}, {}] },
+          })
+        }
+        return Promise.resolve({
+          data: { total_count: 0, items: [] },
+        })
+      }) as unknown as typeof mockOctokit.request
+
+      const stats = await statsService.getContributorStats('testuser')
+
+      expect(stats.prs_total).toBe(3)
+      expect(stats.prs_merged).toBe(0)
+      expect(stats.prs_unmerged).toBe(3)
+      expect(stats.prs_merged_percentage).toBe(0)
+    })
+
+    it('should calculate 100% for all merged PRs', async () => {
+      let callCount = 0
+      mockOctokit.request = mock(() => {
+        callCount++
+        return Promise.resolve({
+          data: { total_count: 4, items: [{}, {}, {}, {}] },
+        })
+      }) as unknown as typeof mockOctokit.request
+
+      const stats = await statsService.getContributorStats('testuser')
+
+      expect(stats.prs_total).toBe(4)
+      expect(stats.prs_merged).toBe(4)
+      expect(stats.prs_unmerged).toBe(0)
+      expect(stats.prs_merged_percentage).toBe(100)
+    })
+
+    it('should use correct search query format', async () => {
+      const requestMock = mock(() =>
+        Promise.resolve({
+          data: { total_count: 0, items: [] },
+        }),
+      )
+      mockOctokit.request = requestMock as unknown as typeof mockOctokit.request
+
+      await statsService.getContributorStats('testuser')
+
+      // Check that it was called with the right parameters
+      expect(requestMock).toHaveBeenCalled()
+      const firstCall = requestMock.mock.calls[0]
+      expect(firstCall[0]).toBe('GET /search/issues')
+      expect(firstCall[1].q).toContain('repo:test-owner/test-repo')
+      expect(firstCall[1].q).toContain('is:pr')
+      expect(firstCall[1].q).toContain('author:testuser')
+    })
+  })
+})

--- a/services/github/index.ts
+++ b/services/github/index.ts
@@ -1,3 +1,4 @@
 export { CommentService } from './comment-service'
 export { IssueService, type RepoContext } from './issue-service'
 export { TeamService } from './team-service'
+export { StatsService, type ContributorStats } from './stats-service'

--- a/services/github/stats-service.ts
+++ b/services/github/stats-service.ts
@@ -1,0 +1,81 @@
+import * as core from '@actions/core'
+import type { OctokitClient } from '../../core'
+import type { RepoContext } from './issue-service'
+
+const API_VERSION = '2022-11-28'
+
+export interface ContributorStats {
+  /** Total number of PRs by the contributor */
+  prs_total: number
+  /** Number of merged PRs by the contributor */
+  prs_merged: number
+  /** Number of unmerged PRs by the contributor */
+  prs_unmerged: number
+  /** Percentage of merged PRs (0-100) */
+  prs_merged_percentage: number
+}
+
+export class StatsService {
+  constructor(
+    private readonly octokit: OctokitClient,
+    private readonly repoContext: RepoContext,
+  ) {}
+
+  /**
+   * Get PR statistics for a contributor in the repository
+   */
+  async getContributorStats(username: string): Promise<ContributorStats> {
+    try {
+      // Fetch all PRs by this user in the repo
+      const allPrs = await this.searchPullRequests(
+        `is:pr author:${username}`,
+      )
+      
+      // Fetch merged PRs by this user
+      const mergedPrs = await this.searchPullRequests(
+        `is:pr author:${username} is:merged`,
+      )
+
+      const total = allPrs.total_count
+      const merged = mergedPrs.total_count
+      const unmerged = total - merged
+      const percentage = total > 0 ? Math.round((merged / total) * 100) : 0
+
+      return {
+        prs_total: total,
+        prs_merged: merged,
+        prs_unmerged: unmerged,
+        prs_merged_percentage: percentage,
+      }
+    } catch (error) {
+      core.warning(`Failed to fetch PR stats for @${username}: ${error}`)
+      // Return zeros if we can't fetch stats
+      return {
+        prs_total: 0,
+        prs_merged: 0,
+        prs_unmerged: 0,
+        prs_merged_percentage: 0,
+      }
+    }
+  }
+
+  /**
+   * Search for pull requests
+   */
+  private async searchPullRequests(
+    query: string,
+  ): Promise<{ total_count: number; items: unknown[] }> {
+    const { owner, repo } = this.repoContext
+    const fullQuery = `repo:${owner}/${repo} ${query}`
+
+    const response = await this.octokit.request('GET /search/issues', {
+      q: fullQuery,
+      advanced_search: 'true',
+      headers: {
+        'X-GitHub-Api-Version': API_VERSION,
+      },
+    })
+
+    return response.data
+  }
+}

--- a/types/comment.ts
+++ b/types/comment.ts
@@ -15,6 +15,14 @@ export interface AssignUserCommentArg {
   total_days: number
   handle: string
   pin_label: string
+  /** Total number of PRs by the contributor */
+  prs_total: number
+  /** Number of merged PRs by the contributor */
+  prs_merged: number
+  /** Number of unmerged PRs by the contributor */
+  prs_unmerged: number
+  /** Percentage of merged PRs (0-100) */
+  prs_merged_percentage: number
 }
 
 export interface UnAssignUserCommentArg {


### PR DESCRIPTION
## Summary

Adds new placeholders to the `assigned_comment` template to display contributor PR statistics:

- `{{ prs_total }}` - Total PRs by the contributor in this repo
- `{{ prs_merged }}` - Number of merged PRs  
- `{{ prs_unmerged }}` - Number of unmerged PRs
- `{{ prs_merged_percentage }}` - Percentage of merged PRs (0-100)

## Usage Example

```yaml
assigned_comment: |
  At this point in time, you have already raised {{ prs_total }} PRs of which {{ prs_merged }} have been merged ({{ prs_merged_percentage }}%).
```

## Implementation

- Added `StatsService` to fetch PR data via GitHub Search API
- Stats are fetched when assigning an issue to a returning contributor
- Graceful fallback to zeros if API calls fail
- Added comprehensive unit tests

Closes #406