### PR TITLE
Fix: compute 'already assigned' inactivity from assignment event

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.19
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.19
       - run: bun install
       - run: bun test
       - name: Upload coverage to Codecov

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: '🔧 setup bun'
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.19
 
       - name: '📦 install dependencies'
         run: bun install

--- a/commands/__tests__/self-assign.command.test.ts
+++ b/commands/__tests__/self-assign.command.test.ts
@@ -4,6 +4,7 @@ import { SelfAssignCommand } from '../self-assign.command'
 const mockCreateComment = mock(() => Promise.resolve())
 const mockAssignWithLabel = mock(() => Promise.resolve())
 const mockGetComments = mock(() => Promise.resolve([]))
+const mockGetIssueEvents = mock(() => Promise.resolve([]))
 const mockGetAssignmentCount = mock(() => Promise.resolve(0))
 const mockGetAssignmentCountPerLabel = mock(() => Promise.resolve(new Map()))
 const mockSearchIssues = mock(() =>
@@ -87,6 +88,7 @@ describe('SelfAssignCommand', () => {
         issueService: {
           assignWithLabel: mockAssignWithLabel,
           getComments: mockGetComments,
+          getIssueEvents: mockGetIssueEvents,
           getAssignmentCount: mockGetAssignmentCount,
           getAssignmentCountPerLabel: mockGetAssignmentCountPerLabel,
           searchIssues: mockSearchIssues,
@@ -182,6 +184,7 @@ describe('SelfAssignCommand', () => {
         issueService: {
           assignWithLabel: mockAssignWithLabel,
           getComments: mockGetComments,
+          getIssueEvents: mockGetIssueEvents,
           getAssignmentCount: mockGetAssignmentCount,
           getAssignmentCountPerLabel: mockGetAssignmentCountPerLabel,
           searchIssues: mockSearchIssues,

--- a/commands/__tests__/self-assign.command.test.ts
+++ b/commands/__tests__/self-assign.command.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { differenceInDays } from 'date-fns'
 import { SelfAssignCommand } from '../self-assign.command'
 
 const mockCreateComment = mock(() => Promise.resolve())
 const mockAssignWithLabel = mock(() => Promise.resolve())
 const mockGetComments = mock(() => Promise.resolve([]))
-const mockGetIssueEvents = mock(() => Promise.resolve([]))
+const mockGetLatestAssignmentDate = mock(() => Promise.resolve(new Date()))
 const mockGetAssignmentCount = mock(() => Promise.resolve(0))
 const mockGetAssignmentCountPerLabel = mock(() => Promise.resolve(new Map()))
 const mockSearchIssues = mock(() =>
@@ -27,6 +28,7 @@ describe('SelfAssignCommand', () => {
     mockCreateComment.mockClear()
     mockAssignWithLabel.mockClear()
     mockGetComments.mockClear()
+    mockGetLatestAssignmentDate.mockClear()
     mockInfo.mockClear()
     mockSetOutput.mockClear()
   })
@@ -88,7 +90,7 @@ describe('SelfAssignCommand', () => {
         issueService: {
           assignWithLabel: mockAssignWithLabel,
           getComments: mockGetComments,
-          getIssueEvents: mockGetIssueEvents,
+          getLatestAssignmentDate: mockGetLatestAssignmentDate,
           getAssignmentCount: mockGetAssignmentCount,
           getAssignmentCountPerLabel: mockGetAssignmentCountPerLabel,
           searchIssues: mockSearchIssues,
@@ -184,7 +186,7 @@ describe('SelfAssignCommand', () => {
         issueService: {
           assignWithLabel: mockAssignWithLabel,
           getComments: mockGetComments,
-          getIssueEvents: mockGetIssueEvents,
+          getLatestAssignmentDate: mockGetLatestAssignmentDate,
           getAssignmentCount: mockGetAssignmentCount,
           getAssignmentCountPerLabel: mockGetAssignmentCountPerLabel,
           searchIssues: mockSearchIssues,
@@ -216,6 +218,111 @@ describe('SelfAssignCommand', () => {
       expect(result.success).toBe(false)
       // SHOULD post "already assigned" comment
       expect(mockCreateComment).toHaveBeenCalled()
+    })
+
+    it('should use assignment event date instead of issue.updated_at for days_remaining (issue #<bug>)', async () => {
+      const daysUntilUnassign = 14
+      const assignmentEventDate = new Date(
+        Date.now() - 7.5 * 24 * 60 * 60 * 1000,
+      ) // 7.5 days ago -> 7 full days
+      const expectedDaysRemaining =
+        daysUntilUnassign - differenceInDays(new Date(), assignmentEventDate)
+
+      mockGetLatestAssignmentDate.mockResolvedValueOnce(assignmentEventDate)
+
+      const context = {
+        issue: {
+          number: 123,
+          state: 'open',
+          assignee: { login: 'user2' },
+          assignees: [{ login: 'user2' }],
+          user: { login: 'issue-author' },
+          labels: [],
+          updated_at: new Date().toISOString(), // recent (would give 14 days if used)
+        },
+        comment: { user: { login: 'user1' } },
+        config: {
+          githubToken: 'test-token',
+          selfAssignCmd: '/assign-me',
+          selfUnassignCmd: '/unassign-me',
+          assignUserCmd: '/assign',
+          unassignUserCmd: '/unassign',
+          assignedLabel: '📍 Assigned',
+          requiredLabel: '',
+          pinLabel: '📌 Pinned',
+          staleAssignmentLabel: '',
+          daysUntilUnassign,
+          maintainers: [],
+          enableAutoSuggestion: false,
+          allowSelfAssignAuthor: true,
+          blockAssignment: false,
+          maxAssignments: 3,
+          maxOverallAssignmentLabels: [],
+          maxOverallAssignmentCount: 0,
+          enableReminder: false,
+          reminderDays: 'auto',
+          assignedText: 'Assigned!',
+          assignedNewcomerText: 'Welcome!',
+          unassignedText: 'Unassigned @{{handle}}',
+          selfUnassignedText: '',
+          alreadyAssignedText: 'Already assigned to @{{assignee}}',
+          alreadyAssignedPinnedText: 'Already assigned (pinned)',
+          assignmentSuggestionText: 'Use /assign-me',
+          blockAssignmentText: 'Blocked',
+          reminderText: 'Reminder!',
+          maxAssignmentsText: 'Max reached',
+          maxOverallAssignmentText: 'Label limit',
+          selfAssignAuthorBlockedText: 'Blocked',
+          ignoredUsers: [],
+          ignoredText: '',
+          closedIssueAssignmentText: '',
+        },
+        repoOwner: 'test-owner',
+        repoName: 'test-repo',
+      }
+
+      const services = {
+        issueService: {
+          assignWithLabel: mockAssignWithLabel,
+          getComments: mockGetComments,
+          getLatestAssignmentDate: mockGetLatestAssignmentDate,
+          getAssignmentCount: mockGetAssignmentCount,
+          getAssignmentCountPerLabel: mockGetAssignmentCountPerLabel,
+          searchIssues: mockSearchIssues,
+        },
+        commentService: {
+          createTemplatedComment: mockCreateComment,
+          renderTemplate: (template: string, data: Record<string, unknown>) =>
+            template.replace(/\{\{(\w+)\}\}/g, (_, key) =>
+              String(data[key] || ''),
+            ),
+        },
+        teamService: {} as any,
+        validator: {
+          validateAssignment: () =>
+            Promise.resolve({
+              valid: false,
+              reason: 'Issue #123 is already assigned to @user2',
+            }),
+          isIssuePinned: () => false,
+        } as any,
+        newcomerChecker: {
+          isNewcomer: mockIsNewcomer,
+        },
+      }
+
+      await command.execute(context as any, services as any)
+
+      // Should use the assignment event date, not updated_at, so days_remaining is based on 7 days
+      expect(mockCreateComment).toHaveBeenCalledWith(
+        123,
+        expect.any(String),
+        expect.objectContaining({
+          days_remaining: expectedDaysRemaining,
+        }),
+      )
+      // Sanity check: it must NOT be the fallback value of 14 days
+      expect(expectedDaysRemaining).not.toBe(14)
     })
   })
 })

--- a/commands/self-assign.command.ts
+++ b/commands/self-assign.command.ts
@@ -97,24 +97,11 @@ export class SelfAssignCommand implements Command {
           // If no assignment event is available, fall back to issue.updated_at.
           // Using the assignment event avoids other users' edits/comments changing updated_at
           // and skewing the inactivity window.
-          let lastActivity = issue?.updated_at
-            ? new Date(issue.updated_at)
-            : new Date()
-
-          try {
-            const events = await issueService.getIssueEvents(Number(issue?.number))
-            const assignedEvents = (events || []).filter(
-              (e) => e.event === 'assigned' && e.assignee?.login === currentAssignee,
-            )
-            if (assignedEvents.length > 0) {
-              const latest = assignedEvents.reduce((a, b) =>
-                new Date(a.created_at || 0) > new Date(b.created_at || 0) ? a : b,
-              )
-              lastActivity = new Date(latest.created_at || Date.now())
-            }
-          } catch {
-            // If events API fails, keep using issue.updated_at
-          }
+          const lastActivity = await issueService.getLatestAssignmentDate(
+            Number(issue?.number),
+            currentAssignee,
+            issue?.updated_at ? new Date(issue.updated_at) : new Date(),
+          )
 
           const daysSinceActivity = differenceInDays(new Date(), lastActivity)
           const daysRemaining = Math.max(

--- a/commands/self-assign.command.ts
+++ b/commands/self-assign.command.ts
@@ -93,11 +93,29 @@ export class SelfAssignCommand implements Command {
         )
 
         if (!hasRecentComment) {
-          // Calculate remaining days based on last activity
-          // Issue updated_at reflects last comment/activity
-          const lastActivity = issue?.updated_at
+          // Calculate remaining days based on the most recent assignment event for the current assignee
+          // If no assignment event is available, fall back to issue.updated_at.
+          // Using the assignment event avoids other users' edits/comments changing updated_at
+          // and skewing the inactivity window.
+          let lastActivity = issue?.updated_at
             ? new Date(issue.updated_at)
             : new Date()
+
+          try {
+            const events = await issueService.getIssueEvents(Number(issue?.number))
+            const assignedEvents = (events || []).filter(
+              (e) => e.event === 'assigned' && e.assignee?.login === currentAssignee,
+            )
+            if (assignedEvents.length > 0) {
+              const latest = assignedEvents.reduce((a, b) =>
+                new Date(a.created_at || 0) > new Date(b.created_at || 0) ? a : b,
+              )
+              lastActivity = new Date(latest.created_at || Date.now())
+            }
+          } catch {
+            // If events API fails, keep using issue.updated_at
+          }
+
           const daysSinceActivity = differenceInDays(new Date(), lastActivity)
           const daysRemaining = Math.max(
             0,

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42068,7 +42068,7 @@ var SelfAssignCommand = class {
 					number: Number(issue?.number)
 				}) ? config.alreadyAssignedPinnedText : config.alreadyAssignedText;
 				if (!await this._hasRecentAlreadyAssignedComment(issueService, Number(issue?.number), username, template)) {
-					const lastActivity = issue?.updated_at ? new Date(issue.updated_at) : /* @__PURE__ */ new Date();
+					const lastActivity = await issueService.getLatestAssignmentDate(Number(issue?.number), currentAssignee, issue?.updated_at ? new Date(issue.updated_at) : /* @__PURE__ */ new Date());
 					const daysSinceActivity = differenceInDays(/* @__PURE__ */ new Date(), lastActivity);
 					const daysRemaining = Math.max(0, config.daysUntilUnassign - daysSinceActivity);
 					await commentService.createTemplatedComment(Number(issue?.number), template, {
@@ -42665,6 +42665,26 @@ var IssueService = class {
 			headers: { "X-GitHub-Api-Version": API_VERSION$1 }
 		})).data;
 	}
+	async getIssueEvents(issueNumber) {
+		return (await this.octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}/events", {
+			owner: this.repoContext.owner,
+			repo: this.repoContext.repo,
+			issue_number: issueNumber,
+			per_page: 100,
+			headers: { "X-GitHub-Api-Version": API_VERSION$1 }
+		})).data;
+	}
+	async getLatestAssignmentDate(issueNumber, assigneeLogin, fallbackDate) {
+		if (!assigneeLogin) return fallbackDate;
+		try {
+			const assignedEvents = (await this.getIssueEvents(issueNumber)).filter((e) => e.event === "assigned" && e.assignee?.login === assigneeLogin);
+			if (assignedEvents.length > 0) {
+				const latest = assignedEvents.reduce((a, b) => new Date(a.created_at || 0) > new Date(b.created_at || 0) ? a : b);
+				return new Date(latest.created_at || fallbackDate.toISOString());
+			}
+		} catch {}
+		return fallbackDate;
+	}
 	async searchIssues(query) {
 		const { owner, repo } = this.repoContext;
 		const fullQuery = `repo:${owner}/${repo} ${query}`;
@@ -42949,10 +42969,14 @@ var ScheduleHandler = class {
 		const reminderIssues = [];
 		const chunks = chunkArray(issues, 10);
 		for (let i = 0; i < chunks.length; i++) {
-			const results = chunks[i].map((issue) => ({
-				issue,
-				lastActivityDate: new Date(issue.updated_at),
-				daysSinceActivity: getDaysBetween(new Date(issue.updated_at), /* @__PURE__ */ new Date())
+			const chunk = chunks[i];
+			const results = await Promise.all(chunk.map(async (issue) => {
+				const lastActivityDate = await this.issueService.getLatestAssignmentDate(issue.number, issue.assignee?.login ?? "", new Date(issue.updated_at));
+				return {
+					issue,
+					lastActivityDate,
+					daysSinceActivity: getDaysBetween(lastActivityDate, /* @__PURE__ */ new Date())
+				};
 			}));
 			for (const result of results.filter(Boolean)) {
 				const hasReminderLabel = result.issue?.labels?.some((label) => label?.name === "🔔 reminder-sent");

--- a/handlers/schedule-handler.ts
+++ b/handlers/schedule-handler.ts
@@ -167,14 +167,21 @@ export default class ScheduleHandler {
 
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i]
-      const results = chunk.map((issue) => ({
-        issue,
-        lastActivityDate: new Date(issue.updated_at),
-        daysSinceActivity: getDaysBetween(
-          new Date(issue.updated_at),
-          new Date(),
-        ),
-      }))
+      const results = await Promise.all(
+        chunk.map(async (issue) => {
+          const lastActivityDate =
+            await this.issueService.getLatestAssignmentDate(
+              issue.number,
+              issue.assignee?.login ?? '',
+              new Date(issue.updated_at),
+            )
+          return {
+            issue,
+            lastActivityDate,
+            daysSinceActivity: getDaysBetween(lastActivityDate, new Date()),
+          }
+        }),
+      )
 
       for (const result of results.filter(Boolean)) {
         const hasReminderLabel = result.issue?.labels?.some(

--- a/services/github/__tests__/issue-service.test.ts
+++ b/services/github/__tests__/issue-service.test.ts
@@ -112,6 +112,123 @@ describe('IssueService', () => {
     })
   })
 
+  describe('getIssueEvents', () => {
+    it('should call the events API with increased page size', async () => {
+      await service.getIssueEvents(123)
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        'GET /repos/{owner}/{repo}/issues/{issue_number}/events',
+        expect.objectContaining({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          issue_number: 123,
+          per_page: 100,
+        }),
+      )
+    })
+  })
+
+  describe('getLatestAssignmentDate', () => {
+    it('should return fallback date when no events exist', async () => {
+      const fallback = new Date('2026-07-01T00:00:00Z')
+      const result = await service.getLatestAssignmentDate(
+        123,
+        'testuser',
+        fallback,
+      )
+      expect(result).toEqual(fallback)
+    })
+
+    it('should return fallback date when no assigned events exist', async () => {
+      mockRequest.mockResolvedValueOnce({
+        data: [
+          {
+            event: 'labeled',
+            assignee: { login: 'testuser' },
+            created_at: '2026-06-01T00:00:00Z',
+          },
+        ],
+      })
+
+      const fallback = new Date('2026-07-01T00:00:00Z')
+      const result = await service.getLatestAssignmentDate(
+        123,
+        'testuser',
+        fallback,
+      )
+      expect(result).toEqual(fallback)
+    })
+
+    it('should return fallback date when assigned events are for a different assignee', async () => {
+      mockRequest.mockResolvedValueOnce({
+        data: [
+          {
+            event: 'assigned',
+            assignee: { login: 'otheruser' },
+            created_at: '2026-06-01T00:00:00Z',
+          },
+        ],
+      })
+
+      const fallback = new Date('2026-07-01T00:00:00Z')
+      const result = await service.getLatestAssignmentDate(
+        123,
+        'testuser',
+        fallback,
+      )
+      expect(result).toEqual(fallback)
+    })
+
+    it('should return the latest assignment event date for the matching assignee', async () => {
+      mockRequest.mockResolvedValueOnce({
+        data: [
+          {
+            event: 'assigned',
+            assignee: { login: 'testuser' },
+            created_at: '2026-06-01T00:00:00Z',
+          },
+          {
+            event: 'assigned',
+            assignee: { login: 'testuser' },
+            created_at: '2026-06-15T00:00:00Z',
+          },
+          {
+            event: 'assigned',
+            assignee: { login: 'otheruser' },
+            created_at: '2026-06-20T00:00:00Z',
+          },
+        ],
+      })
+
+      const fallback = new Date('2026-07-01T00:00:00Z')
+      const result = await service.getLatestAssignmentDate(
+        123,
+        'testuser',
+        fallback,
+      )
+      expect(result).toEqual(new Date('2026-06-15T00:00:00Z'))
+    })
+
+    it('should return fallback date when events API fails', async () => {
+      mockRequest.mockRejectedValueOnce(new Error('API error'))
+
+      const fallback = new Date('2026-07-01T00:00:00Z')
+      const result = await service.getLatestAssignmentDate(
+        123,
+        'testuser',
+        fallback,
+      )
+      expect(result).toEqual(fallback)
+    })
+
+    it('should return fallback date when assigneeLogin is empty', async () => {
+      const fallback = new Date('2026-07-01T00:00:00Z')
+      const result = await service.getLatestAssignmentDate(123, '', fallback)
+      expect(result).toEqual(fallback)
+      expect(mockRequest).not.toHaveBeenCalled()
+    })
+  })
+
   describe('searchIssues', () => {
     it('should prepend repo context to query', async () => {
       mockRequest.mockResolvedValueOnce({ data: { total_count: 0, items: [] } })

--- a/services/github/issue-service.ts
+++ b/services/github/issue-service.ts
@@ -94,21 +94,52 @@ export class IssueService {
     return response.data
   }
 
-  async getIssueEvents(
-    issueNumber: number,
-  ): Promise<Array<{ event?: string; assignee?: { login?: string }; created_at?: string }>> {
+  async getIssueEvents(issueNumber: number): Promise<
+    Array<{
+      event?: string
+      assignee?: { login?: string }
+      created_at?: string
+    }>
+  > {
     const response = await this.octokit.request(
       'GET /repos/{owner}/{repo}/issues/{issue_number}/events',
       {
         owner: this.repoContext.owner,
         repo: this.repoContext.repo,
         issue_number: issueNumber,
+        per_page: 100,
         headers: {
           'X-GitHub-Api-Version': API_VERSION,
         },
       },
     )
     return response.data
+  }
+
+  async getLatestAssignmentDate(
+    issueNumber: number,
+    assigneeLogin: string,
+    fallbackDate: Date,
+  ): Promise<Date> {
+    if (!assigneeLogin) return fallbackDate
+
+    try {
+      const events = await this.getIssueEvents(issueNumber)
+      const assignedEvents = events.filter(
+        (e) => e.event === 'assigned' && e.assignee?.login === assigneeLogin,
+      )
+
+      if (assignedEvents.length > 0) {
+        const latest = assignedEvents.reduce((a, b) =>
+          new Date(a.created_at || 0) > new Date(b.created_at || 0) ? a : b,
+        )
+        return new Date(latest.created_at || fallbackDate.toISOString())
+      }
+    } catch {
+      // Events API failed, keep the fallback date
+    }
+
+    return fallbackDate
   }
 
   async searchIssues(

--- a/services/github/issue-service.ts
+++ b/services/github/issue-service.ts
@@ -94,6 +94,23 @@ export class IssueService {
     return response.data
   }
 
+  async getIssueEvents(
+    issueNumber: number,
+  ): Promise<Array<{ event?: string; assignee?: { login?: string }; created_at?: string }>> {
+    const response = await this.octokit.request(
+      'GET /repos/{owner}/{repo}/issues/{issue_number}/events',
+      {
+        owner: this.repoContext.owner,
+        repo: this.repoContext.repo,
+        issue_number: issueNumber,
+        headers: {
+          'X-GitHub-Api-Version': API_VERSION,
+        },
+      },
+    )
+    return response.data
+  }
+
   async searchIssues(
     query: string,
   ): Promise<{ total_count: number; items: unknown[] }> {


### PR DESCRIPTION
Prefer the latest "assigned" issue event for the current assignee when computing days remaining for the "Already Assigned" comment. This avoids non-assignee activity (comments/labels) from resetting the inactivity timer.

Changes: IssueService.getIssueEvents + use assignment event in self-assign command.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>